### PR TITLE
feat: 단축 url 호출 시 원래 url로 리다이렉트하는 기능 구현

### DIFF
--- a/src/main/java/io/changhyun/surl/controller/UrlCallController.java
+++ b/src/main/java/io/changhyun/surl/controller/UrlCallController.java
@@ -1,0 +1,43 @@
+package io.changhyun.surl.controller;
+
+import io.changhyun.surl.exception.InvalidUrlException;
+import io.changhyun.surl.service.UrlReadService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.net.URI;
+import java.net.URISyntaxException;
+
+@RestController
+@RequiredArgsConstructor
+@Slf4j
+public class UrlCallController {
+
+    private final UrlReadService urlReadService;
+
+    @GetMapping("/{code}")
+    public ResponseEntity<?> redirectToOriginalUrl(@PathVariable String code) {
+        String originalUrl = urlReadService.findOriginalUrl(code);
+
+        try {
+            URI uri = new URI(originalUrl);
+
+            HttpHeaders headers = new HttpHeaders();
+            headers.setLocation(uri);
+
+            return ResponseEntity
+                    .status(HttpStatus.FOUND)
+                    .headers(headers)
+                    .build();
+        } catch (URISyntaxException e) {
+            log.error("유효한 형식의 URL이 아닙니다. code = {}, originalUrl = {}", code, originalUrl);
+            throw new InvalidUrlException("유효한 형식의 URL이 아닙니다.");
+        }
+    }
+}

--- a/src/main/java/io/changhyun/surl/enums/UrlStatus.java
+++ b/src/main/java/io/changhyun/surl/enums/UrlStatus.java
@@ -1,0 +1,17 @@
+package io.changhyun.surl.enums;
+
+import lombok.Getter;
+
+@Getter
+public enum UrlStatus {
+    ACTIVE("ACTIVE"),
+    EXPIRED("EXPIRED"),
+    DELETED("DELETED")
+    ;
+
+    private final String label;
+
+    UrlStatus(String label) {
+        this.label = label;
+    }
+}

--- a/src/main/java/io/changhyun/surl/service/UrlReadService.java
+++ b/src/main/java/io/changhyun/surl/service/UrlReadService.java
@@ -1,0 +1,38 @@
+package io.changhyun.surl.service;
+
+import io.changhyun.surl.data.domain.ShortenedUrl;
+import io.changhyun.surl.enums.UrlStatus;
+import io.changhyun.surl.exception.UrlNotFoundException;
+import io.changhyun.surl.repository.ShortenedUrlRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+import java.util.Optional;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class UrlReadService {
+
+    private final ShortenedUrlRepository shortenedUrlRepository;
+
+    public String findOriginalUrl(String code) {
+        Optional<ShortenedUrl> optional = shortenedUrlRepository.findByCode(code);
+
+        if (optional.isEmpty()) {
+            log.warn("저장된 Original URL을 찾을 수 없습니다. code = {}", code);
+            throw new UrlNotFoundException("URL을 찾을 수 없습니다.");
+        }
+
+        ShortenedUrl entity = optional.get();
+        String status = entity.getStatus().getStatusName();
+
+        if (status.equals(UrlStatus.ACTIVE.getLabel())) {
+            return entity.getOriginalUrl();
+        } else {
+            // TODO: 실패 화면으로 redirect
+            return null;
+        }
+    }
+}


### PR DESCRIPTION
## 작업 내용

### url 상태 관리
- `UrlStatus`: url 상태를 enum으로 관리

### 단축 url를 사용해 원래 url로 리다이렉트 하는 기능 구현
- 활성(`Active`) 상태인 경우 해당 url로 리다이렉트
- 나머지 상태의 경우, 화면 구현을 먼저 한 다음 처리할 예정
